### PR TITLE
Use timeout instead of delay after DFU_DETACH

### DIFF
--- a/fwup/dfu.py
+++ b/fwup/dfu.py
@@ -145,8 +145,12 @@ class DFUTarget(FwupTarget):
 
         # ... and ensure the relevant configuration is active.
         try:
-            self.device.set_configuration(self.configuration)
             self.device.detach_kernel_driver(self.interface)
+        except:
+            pass
+
+        try:
+            self.device.set_configuration(self.configuration)
         except:
             pass
 


### PR DESCRIPTION
Enable override of default 5 second timeout. Previously there was a fixed delay of 3 seconds. Now we allow more time (up to the timeout) but may succeed in much less than 3 seconds.